### PR TITLE
Support of .git folder and .gitignore 

### DIFF
--- a/commands/cli.js
+++ b/commands/cli.js
@@ -99,3 +99,12 @@ function handleFile(path, files) {
   const data = fs.readFileSync(path)
   files.push({ path, data })
 }
+
+function getAbsolutePath(entryPath) {
+  var absolutePath = path.join(entryPath)
+
+  if (absolutePath.startsWith(`..${path.sep}`)) return absolutePath.substr(3)
+  if (absolutePath.startsWith(`${path.sep}`)) return absolutePath.substr(1)
+
+  return absolutePath;
+}

--- a/commands/cli.js
+++ b/commands/cli.js
@@ -28,20 +28,16 @@ export function normalizeFolderPath(folderPath) {
   return path.normalize(folderPath.endsWith(path.sep) ? folderPath.slice(0, -1) : folderPath)
 }
 
-export function getFiles(folderPath, isGitFolder=false) {
+export function getFiles(folderPath, includeGitIgnoredFiles=false) {
 
   let files = []
-  let filters = []
+  let filters = ['.git/']
   
-  // if the folder is git folder then we should ignore 
-  // .git and files / folders in gitignore
-  if (isGitFolder){
-    
+  // if we don't want to include git ignored files, we add filters
+  if (!includeGitIgnoredFiles){
     if (fs.existsSync('.gitignore')) {
-      filters = parse(fs.readFileSync('.gitignore'))['patterns'];
+      filters.push(...parse(fs.readFileSync('.gitignore'))['patterns']);
     } 
-    
-    filters.push('.git/')
   }
   
   if (fs.statSync(folderPath).isDirectory()) {

--- a/commands/cli.js
+++ b/commands/cli.js
@@ -89,7 +89,8 @@ function handleDirectory(entry, files, filters ) {
     });
   } else {
     // check if file's pattern corresponds to gitignore patterns
-    if(!gitignore.ignores(path.join(entry))){
+    const absolutePath = getAbsolutePath(entry)
+    if(!gitignore.ignores(absolutePath)){
       handleFile(entry, files);
     }
   }

--- a/commands/cli.js
+++ b/commands/cli.js
@@ -36,7 +36,11 @@ export function getFiles(folderPath, isGitFolder=false) {
   // if the folder is git folder then we should ignore 
   // .git and files / folders in gitignore
   if (isGitFolder){
-    filters = parse(fs.readFileSync('.gitignore'))['patterns'];
+    
+    if (fs.existsSync('.gitignore')) {
+      filters = parse(fs.readFileSync('.gitignore'))['patterns'];
+    } 
+    
     filters.push('.git/')
   }
   

--- a/commands/deploy.js
+++ b/commands/deploy.js
@@ -34,8 +34,8 @@ const builder = {
     demandOption: true, // Required
     type: 'string',
   },
-  "git-folder": {
-    describe: 'Upload a git folder',
+  "include-git-ignored-files": {
+    describe: 'Upload files referenced in .gitignore',
     demandOption: false,
     type: 'boolean',
   },
@@ -59,8 +59,8 @@ const handler = async function (argv) {
       sslKey
     } = cli.loadSSL(argv['ssl-certificate'], argv['ssl-key'])
 
-    // Is git folder
-    const isGitFolder = argv['git-folder']
+    // Should include git ignored files
+    const includeGitIgnoredFiles = argv['include-git-ignored-files']
     
     // Get the path
     const folderPath = cli.normalizeFolderPath(argv.path)
@@ -90,7 +90,7 @@ const handler = async function (argv) {
     console.log(chalk.blue('Creating file structure and compress content...'))
 
     const aeweb = new AEWeb(archethic)
-    const files = cli.getFiles(folderPath, isGitFolder)
+    const files = cli.getFiles(folderPath, includeGitIgnoredFiles)
 
     if (files.length === 0) throw 'folder "' + path.basename(folderPath) + '" is empty'
 

--- a/commands/deploy.js
+++ b/commands/deploy.js
@@ -34,7 +34,11 @@ const builder = {
     demandOption: true, // Required
     type: 'string',
   },
-
+  "git-folder": {
+    describe: 'Upload a git folder',
+    demandOption: false,
+    type: 'boolean',
+  },
   "ssl-certificate": {
     describe: 'SSL certificate to link to the website',
     demandOption: false,
@@ -55,6 +59,10 @@ const handler = async function (argv) {
       sslKey
     } = cli.loadSSL(argv['ssl-certificate'], argv['ssl-key'])
 
+    // Is git folder
+    const isGitFolder = argv['git-folder']
+    
+    // Get the path
     const folderPath = cli.normalizeFolderPath(argv.path)
 
     // Get seeds
@@ -82,7 +90,7 @@ const handler = async function (argv) {
     console.log(chalk.blue('Creating file structure and compress content...'))
 
     const aeweb = new AEWeb(archethic)
-    const files = cli.getFiles(folderPath)
+    const files = cli.getFiles(folderPath, isGitFolder)
 
     if (files.length === 0) throw 'folder "' + path.basename(folderPath) + '" is empty'
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,9 @@
         "archethic": "^1.13.0",
         "chalk": "^5.0.1",
         "figlet": "^1.5.2",
+        "ignore": "^5.2.0",
         "lodash": "^4.17.21",
+        "parse-gitignore": "^2.0.0",
         "yargs": "^17.5.1",
         "yesno": "^0.4.0"
       },
@@ -629,6 +631,14 @@
         }
       ]
     },
+    "node_modules/ignore": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -736,6 +746,14 @@
         "evp_bytestokey": "^1.0.0",
         "pbkdf2": "^3.0.3",
         "safe-buffer": "^5.1.1"
+      }
+    },
+    "node_modules/parse-gitignore": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/parse-gitignore/-/parse-gitignore-2.0.0.tgz",
+      "integrity": "sha512-RmVuCHWsfu0QPNW+mraxh/xjQVw/lhUCUru8Zni3Ctq3AoMhpDTq0OVdKS6iesd6Kqb7viCV3isAL43dciOSog==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/pbkdf2": {
@@ -1549,6 +1567,11 @@
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
     },
+    "ignore": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ=="
+    },
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -1640,6 +1663,11 @@
         "pbkdf2": "^3.0.3",
         "safe-buffer": "^5.1.1"
       }
+    },
+    "parse-gitignore": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/parse-gitignore/-/parse-gitignore-2.0.0.tgz",
+      "integrity": "sha512-RmVuCHWsfu0QPNW+mraxh/xjQVw/lhUCUru8Zni3Ctq3AoMhpDTq0OVdKS6iesd6Kqb7viCV3isAL43dciOSog=="
     },
     "pbkdf2": {
       "version": "3.1.2",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,9 @@
     "archethic": "^1.13.0",
     "chalk": "^5.0.1",
     "figlet": "^1.5.2",
+    "ignore": "^5.2.0",
     "lodash": "^4.17.21",
+    "parse-gitignore": "^2.0.0",
     "yargs": "^17.5.1",
     "yesno": "^0.4.0"
   },


### PR DESCRIPTION
As described in #82 aeweb-cli wasn't handeling git folders.
Therefore I added a `--git-folder` argument.

It works by parsing the .gitignore file and then only uploading files that do not match the gitignore patterns.

to test it simply deploy a git folder as usual but add the `--git-folder` argument.