### PR TITLE
Handle website update #83

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -1,41 +1,50 @@
 import zlib from 'zlib'
-import isEqual from 'lodash/isEqual.js'
-import path from 'path'
-import Archethic, { Crypto, Utils } from 'archethic'
+import Archethic, { Crypto } from 'archethic'
+import {
+  hashContent, getFilePath, MAX_FILE_SIZE, handleBigFile, handleNormalFile,
+  getRefTxContent
+} from "./utils.js"
 
 const { aesEncrypt, ecEncrypt, randomSecretKey } = Crypto
-const { uint8ArrayToHex } = Utils
-import nativeCryptoLib from 'crypto'
-
-// 3_145_728 represent the maximum size for a transaction
-// 45_728 represent json tree size
-const MAX_FILE_SIZE = 3_145_728 - 45_728
-const AEWEB_VERSION = 1
-const HASH_FUNCTION = 'sha1'
-
 export default class AEWeb {
-  constructor(archethic) {
+
+  constructor(archethic, prevRefTxContent = undefined) {
     if (!(archethic instanceof Archethic)) {
       throw 'archethic is not an instance of Archethic'
     }
+
+    if (prevRefTxContent !== undefined) this.prevRefTxMetaData = prevRefTxContent.metaData
     this.archethic = archethic
     this.txsContent = []
     this.metaData = {}
+    this.modifiedFiles = []
   }
 
   addFile(naivePath, data) {
     const size = Buffer.byteLength(data)
     if (size === 0) return
 
-    const hash = nativeCryptoLib.createHash(HASH_FUNCTION).update(data).digest('hex')
-    const content = zlib.gzipSync(data).toString('base64url')
+    const hash = hashContent(data)
+    const filePath = getFilePath(naivePath)
 
-    const tabPath = naivePath.split(path.sep)
-    if (tabPath[0] === '') tabPath.shift()
-    const filePath = tabPath.join('/')
+    if (this.prevRefTxMetaData !== undefined) {
+      // A website update operation
+      const prevFileMetaData = this.prevRefTxMetaData[filePath];
+      delete (this.prevRefTxMetaData[filePath]);
+
+      if (prevFileMetaData != undefined && prevFileMetaData["hash"] == hash) {
+        // File exists and  not changed
+        // priority given to new files/metadata
+        this.metaData[filePath] = prevFileMetaData;
+        return;
+      }
+    }
+    // File has changed or is new
+    this.modifiedFiles.push(filePath);
 
     this.metaData[filePath] = { hash: hash, size: size, encoding: 'gzip', addresses: [] }
 
+    const content = zlib.gzipSync(data).toString('base64url')
     // Handle file over than Max size. The file is splitted in multiple transactions,
     // firsts parts take a full transaction, the last part follow the normal sized file construction
     if (content.length >= MAX_FILE_SIZE) {
@@ -62,11 +71,11 @@ export default class AEWeb {
 
       return tx
     })
+
   }
 
   async getRefTransaction(transactions) {
-    const { metaData, refContent } = getMetaData(this.txsContent, transactions, this.metaData, this.sslCertificate)
-    this.metaData = metaData
+    const refContent = getRefTxContent(this.txsContent, transactions, this.metaData, this.sslCertificate)
 
     const refTx = this.archethic.transaction.new()
       .setType('hosting')
@@ -80,7 +89,6 @@ export default class AEWeb {
 
       refTx.addOwnership(encryptedSslKey, [{ publicKey: storageNoncePublicKey, encryptedSecretKey: encryptedSecretKey }])
     }
-
     return refTx
   }
 
@@ -90,96 +98,13 @@ export default class AEWeb {
     this.sslKey = undefined
     this.metaData = {}
   }
-}
 
-function handleBigFile(txsContent, filePath, content) {
-  while (content.length > 0) {
-    // Split the file
-    const part = content.slice(0, MAX_FILE_SIZE)
-    content = content.replace(part, '')
-    // Set the value in transaction content
-    const txContent = {
-      content: {},
-      size: part.length,
-      refPath: [],
-    }
-    txContent.content[filePath] = part
-    txContent.refPath.push(filePath)
-    txsContent.push(txContent)
+  listModifiedFiles() {
+    return this.modifiedFiles;
+  }
+
+  listRemovedFiles() {
+    return Object.keys(this.prevRefTxMetaData);
   }
 }
 
-function handleNormalFile(txsContent, filePath, content) {
-  // 4 x "inverted commas + 1x :Colon + 1x ,Comma + 1x space = 7
-  const fileSize = content.length + filePath.length + 7
-  // Get first transaction content that can be filled with file content
-  const txContent = getContentToFill(txsContent, fileSize)
-  const index = txsContent.indexOf(txContent)
-
-  txContent.content[filePath] = content
-  txContent.refPath.push(filePath)
-  txContent.size += fileSize
-
-  if (index === -1) {
-    // Push new transaction
-    txsContent.push(txContent)
-  } else {
-    // Update existing transaction
-    txsContent.splice(index, 1, txContent)
-  }
-}
-
-function getContentToFill(txsContent, contentSize) {
-  const content = txsContent.find(txContent => (txContent.size + contentSize) <= MAX_FILE_SIZE)
-  if (content) {
-    return content
-  } else {
-    return {
-      content: {},
-      size: 0,
-      refPath: []
-    }
-  }
-}
-
-function getMetaData(txsContent, transactions, metaData, sslCertificate) {
-  // For each transaction
-  transactions.forEach((tx) => {
-    if (!tx.address) throw 'Transaction is not built'
-
-    const txContent = txsContent.find(val => isEqual(val.content, tx.data.content))
-
-    if (!txContent) throw 'Transaction content not expected'
-    // For each filePath
-    const address = uint8ArrayToHex(tx.address)
-    // Update the metadata at filePath with address
-    return txContent.refPath.forEach((filePath) => {
-      const { addresses } = metaData[filePath]
-      addresses.push(address)
-      metaData[filePath]['addresses'] = addresses
-    })
-  })
-
-  metaData = sortObject(metaData)
-
-  const ref = {
-    aewebVersion: AEWEB_VERSION,
-    hashFunction: HASH_FUNCTION,
-    metaData: metaData
-  }
-
-  if (sslCertificate) {
-    ref.sslCertificate = sslCertificate
-  }
-
-  return { metadata: metaData, refContent: JSON.stringify((ref)) }
-}
-
-function sortObject(obj) {
-  return Object.keys(obj)
-    .sort()
-    .reduce(function (acc, key) {
-      acc[key] = obj[key]
-      return acc
-    }, {})
-}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,117 @@
+import { Crypto, Utils } from 'archethic'
+import nativeCryptoLib from 'crypto'
+import * as PathLib from 'path'
+import isEqual from 'lodash/isEqual.js'
+const { uint8ArrayToHex } = Utils
+
+
+// 3_145_728 represent the maximum size for a transaction
+// 45_728 represent json tree size
+// 3mb in binary 
+export const MAX_FILE_SIZE = 3_145_728 - 45_728
+export const AEWEB_VERSION = 1
+export const HASH_FUNCTION = 'sha1'
+
+export function getFilePath(naivePath) {
+    const jsonPath = naivePath.split(PathLib.sep)
+    if (jsonPath[0] === '') jsonPath.shift()
+    return jsonPath.join('/');
+}
+
+export function hashContent(data) {
+    return nativeCryptoLib.createHash(HASH_FUNCTION).update(data).digest('hex')
+}
+
+export function handleBigFile(txsContent, filePath, content) {
+    while (content.length > 0) {
+        // Split the file
+        const part = content.slice(0, MAX_FILE_SIZE)
+        content = content.replace(part, '')
+        // Set the value in transaction content
+        const txContent = {
+            content: {},
+            size: part.length,
+            refPath: [],
+        }
+        txContent.content[filePath] = part
+        txContent.refPath.push(filePath)
+        txsContent.push(txContent)
+    }
+}
+
+export function handleNormalFile(txsContent, filePath, content) {
+    // 4 x "inverted commas + 1x :Colon + 1x ,Comma + 1x space = 7
+    const fileSize = content.length + filePath.length + 7
+    // Get first transaction content that can be filled with file content
+    const txContent = getContentToFill(txsContent, fileSize)
+    const index = txsContent.indexOf(txContent)
+
+    txContent.content[filePath] = content
+    txContent.refPath.push(filePath)
+    txContent.size += fileSize
+
+    if (index === -1) {
+        // Push new transaction
+        txsContent.push(txContent)
+    } else {
+        // Update existing transaction
+        txsContent.splice(index, 1, txContent)
+    }
+}
+
+function getContentToFill(txsContent, contentSize) {
+    const content = txsContent.find(txContent => (txContent.size + contentSize) <= MAX_FILE_SIZE)
+    if (content) {
+        return content
+    } else {
+        return {
+            content: {},
+            size: 0,
+            refPath: []
+        }
+    }
+}
+
+export function getRefTxContent(txsContent, transactions, metaData, sslCertificate) {
+    // For each transaction
+    transactions.forEach((tx) => {
+        if (!tx.address) throw 'Transaction is not built'
+
+        const txContent = txsContent.find(val => isEqual(val.content, tx.data.content))
+
+        if (!txContent) throw 'Transaction content not expected'
+        // For each filePath
+        const address = uint8ArrayToHex(tx.address)
+        // Update the metadata at filePath with address
+        return txContent.refPath.forEach((filePath) => {
+            const { addresses } = metaData[filePath]
+            addresses.push(address)
+            metaData[filePath]['addresses'] = addresses
+        })
+    })
+
+    metaData = sortObject(metaData)
+
+    const ref = {
+        aewebVersion: AEWEB_VERSION,
+        hashFunction: HASH_FUNCTION,
+        metaData: metaData
+    }
+
+    if (sslCertificate) {
+        ref.sslCertificate = sslCertificate
+    }
+
+    return JSON.stringify(ref);
+}
+
+function sortObject(obj) {
+    return Object.keys(obj)
+        .sort()
+        .reduce(function (acc, key) {
+            acc[key] = obj[key]
+            return acc
+        }, {})
+}
+
+


### PR DESCRIPTION
This pr provides api to handle website update. When we upload a website, we might need to do some updates.
Redeploying from scratch is not an option.
Current One seed one website.
We must provide freedom to update website.

we fetch prev ref tx and compare its metadata with the updates files that user has provided.
We update metadata, for the changes files and include new files. 