### PR TITLE
Fix deploy

### DIFF
--- a/commands/cli.js
+++ b/commands/cli.js
@@ -32,7 +32,7 @@ export function getFiles(folderPath) {
     handleDirectory(folderPath, files)
 
     files = files.map(file => {
-      file.path = file.path.replace(folderPath, '')
+      file.filePath = file.filePath.replace(folderPath, '')
       return file
     })
   } else {
@@ -77,6 +77,6 @@ function handleDirectory(entry, files) {
 }
 
 function handleFile(filePath, files) {
-  const data = fs.readFileSync(path)
+  const data = fs.readFileSync(filePath)
   files.push({ filePath, data })
 }


### PR DESCRIPTION
Yesterday's commit introduced a regression and we could not upload folder anymore:

```
[bastien@T495 aeweb-cli]$ ./aeweb.js deploy --endpoint http://127.0.0.1:4000 --seed bastien --path ~/Chamagne/archethic/archethic-website/
Connecting to http://127.0.0.1:4000
Creating file structure and compress content...
TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string or an instance of Buffer or URL. Received an instance of Object
```

This fixes it