### PR TITLE
Fix initial website hosting tx when tx already exist

### DIFF
--- a/commands/deploy.js
+++ b/commands/deploy.js
@@ -332,7 +332,6 @@ async function fetchLastHostingTx(txnAddress, archethic) {
     txnAddress = uint8ArrayToHex(txnAddress);
   }
 
-  // Requête pour obtenir la dernière transaction
   const lastTxQuery = `
   query {
     lastTransaction(
@@ -362,7 +361,6 @@ async function fetchLastHostingTx(txnAddress, archethic) {
   while (txn.previousAddress) {
     txnAddress = txn.previousAddress;
 
-    // Requête pour obtenir une transaction spécifique
     const txQuery = `
     query {
       transaction(

--- a/commands/deploy.js
+++ b/commands/deploy.js
@@ -149,9 +149,13 @@ const handler = async function(argv) {
     // Check if website is already deployed
     if (refIndex !== 0) {
       console.log(archethic.nearestEndpoints)
-      isWebsiteUpdate = true;
       const lastRefTx = await fetchLastRefTx(refAddress, archethic);
-      prevRefTxContent = JSON.parse(lastRefTx.data.content);
+      try{
+        prevRefTxContent = JSON.parse(lastRefTx.data.content);
+        isWebsiteUpdate = true;
+      } catch (e){
+        console.warn('No existing transaction found on refAddress for hosting the website. This will be considered as the initial hosting transaction.');
+      }
     }
 
     // Convert directory structure into array of file content


### PR DESCRIPTION
This PR addresses issue #117.

### Problem description
It was impossible to deploy the website using the following command:

```powershell
aeweb deploy --seed "PrivateAddressAeWalletInHexadecimalFormat" --endpoint https://testnet.archethic.net --path ./website --keychain-funding-service "archethic-wallet-fundingName" --keychain-website-service "archethic-wallet-WebSiteHostingName"
```

### Steps to manage the problem

1. Via AeWallet: Create the keychains "fundingName" and "WebSiteHostingName".
2. Via AeWallet: Send UCO with messages to "fundingName" and "WebSiteHostingName".
3. Via AeWallet: send UCO with messages from "WebSiteHostingName" to "fundingName"
4. Via AeWallet: Retrieve the private address of the wallet in hexadecimal format via the dedicated menu (Menu/Security/SecretRecoveryPhrase => button View in Hexadecimal).
5. Run the command:

```powershell
aeweb deploy --seed "PrivateAddressAeWalletInHexadecimalFormat" --endpoint https://testnet.archethic.net --path ./website --keychain-funding-service "archethic-wallet-fundingName" --keychain-website-service "archethic-wallet-WebSiteHostingName"
```

Error Output:

```powershell
Connecting to https://testnet.archethic.net
Fetching keychain...
Keychain loaded with the funding/website services
Set(13) {
  'http://185.34.143.63:4000',
  'http://185.34.143.66:4000',
  'http://188.166.236.224:4000',
  'http://185.34.143.65:4000',
  'http://185.34.143.68:4000',
  'http://64.227.8.83:40000',
  'http://185.34.143.64:4000',
  'http://170.64.192.184:4000',
  'http://185.34.143.67:4001',
  'http://139.59.149.234:40000',
  'http://164.92.66.71:4000',
  'http://64.227.136.218:40000',
  'https://testnet.archethic.net'
}
SyntaxError: Unexpected end of JSON input
```

### Root cause of the problem

- The keychain "archethic-wallet-WebSiteHostingName" contains an initial transaction related to UCO sent in step 3.
- The algorithm in the file commands/deploy.js tries to parse the JSON message of the last transaction of type "host" to check if the website needs to be updated.
- In this specific case, there is no transaction of type "host", so fetchLastRefTx returns an empty object, and the parse function throws an exception.
- However, the keychain is valid and should be able to initialize a first transaction of type "host website".

### Proposed Solution

Search for the last hosting transaction and, if no such transaction is found, initiate a hosting transaction for the first time

### Tests Performed on testnet

I have conducted the following tests to ensure the functionality and robustness of the changes:

1. **Test with an empty keychain**:
   - Verified that the function handles an empty keychain without errors.

2. **Test with a keychain containing only "transaction" type entries**:
   - Confirmed that the function correctly processes a keychain with entries of type "transaction" and ignores non-"hosting" types.

3. **Test with a keychain where the last transaction is not of type "hosting"**:
   - Ensured that the function correctly identifies that there is no "hosting" type transaction in the last transaction.

4. **Test with a keychain where the last transaction is of type "hosting"**:
   - Verified that the function accurately retrieves the last transaction of type "hosting" and processes it correctly.